### PR TITLE
Implement issues #1-#4: core API refactor, cross-platform tooling, CLI, and keyring credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - _Nothing yet._
 
+## [0.6.0] - 2026-02-25
+
+### Added
+- New pure Python core facade (`src/core/api.py`) for workflow operations (`import_dataset`, `publish`, `fetch`, `restore`, history/status helpers) with callback-driven progress/error/cancel hooks.
+- New headless CLI entry point (`cli.py`) with `datagest status` and `datagest sync`.
+- New keyring-backed credential utility (`src/core/credential_manager.py`) and test coverage.
+
+### Changed
+- UI workflow execution now uses UI-owned Qt worker wrappers (`CoreTaskRunner`) that call the core API, instead of coupling business logic to Qt workflow classes.
+- Platform/runtime behavior is now OS-agnostic for user/machine identity and local app config paths (`~/.config/datagest` on Unix).
+- Tool bootstrap now prefers system `git`/`dvc` from `PATH` on non-Windows hosts.
+
+### Fixed
+- Subprocess creation flags are now applied only on Windows, preventing Unix crashes from Windows-only flags.
+
 ## [0.5.1] - 2026-02-18
 
 ### Fixed

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+# ruff: noqa: E402
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from core.api import DataGestCore
+from core.config import load_config
+from core.dvc_manager import DVCManager
+from core.git_manager import GitManager
+from core.lock_manager import LockManager
+from core.registry import RegistryLoader
+from core.tool_bootstrap import ToolBootstrap
+from core.workspace import WorkspaceManager
+from models.project import ProjectConfig
+
+
+def _progress_printer(message: str, percent: int) -> None:
+    width = 30
+    clamped = max(0, min(100, percent))
+    filled = int(width * clamped / 100)
+    bar = "#" * filled + "-" * (width - filled)
+    line = f"\r[{bar}] {clamped:3d}% {message[:80]}"
+    sys.stdout.write(line)
+    sys.stdout.flush()
+    if clamped >= 100:
+        sys.stdout.write("\n")
+        sys.stdout.flush()
+
+
+def _error_printer(message: str) -> None:
+    if not message:
+        return
+    if not message.endswith("\n"):
+        message = f"{message}\n"
+    sys.stderr.write(message)
+    sys.stderr.flush()
+
+
+def _build_core() -> tuple[DataGestCore, list[ProjectConfig]]:
+    config = load_config()
+    bootstrap = ToolBootstrap(config)
+
+    git_exe = shutil.which("git") or config.git_executable
+    dvc_exe = shutil.which("dvc") or config.dvc_executable
+
+    if not git_exe:
+        git_exe = str(bootstrap.ensure_git())
+    if not dvc_exe:
+        dvc_exe = str(bootstrap.ensure_dvc())
+
+    root = Path(config.workspace_root)
+    git_manager = GitManager(
+        root,
+        git_executable=git_exe,
+        timeout_seconds=config.git_timeout_seconds,
+    )
+    dvc_manager = DVCManager(
+        root,
+        dvc_executable=dvc_exe,
+        timeout_seconds=config.dvc_timeout_seconds,
+    )
+    workspace = WorkspaceManager(root, git_manager, dvc_manager)
+    lock_manager = LockManager(
+        Path(config.locks_path),
+        ttl_hours=config.lock_ttl_hours,
+        admin_mode=config.admin_mode,
+    )
+    core = DataGestCore(workspace, lock_manager)
+
+    projects = RegistryLoader(config.registry_path).load()
+    return core, projects
+
+
+def _select_project(projects: list[ProjectConfig], project_id: str | None) -> ProjectConfig:
+    if not projects:
+        raise RuntimeError("No project found in registry.")
+
+    if project_id:
+        for project in projects:
+            if project.project_id == project_id:
+                return project
+        raise RuntimeError(f"Project '{project_id}' not found in registry.")
+
+    if len(projects) == 1:
+        return projects[0]
+
+    ids = ", ".join(project.project_id for project in projects)
+    raise RuntimeError(f"Multiple projects found ({ids}). Pass --project.")
+
+
+def _run_status(args: argparse.Namespace) -> int:
+    core, projects = _build_core()
+    project = _select_project(projects, args.project)
+    status = core.get_status(project)
+
+    print(f"Project: {status.project_id}")
+    print(f"Workspace: {status.workspace_path}")
+    print(f"State: {status.state.value}")
+    print(f"Branch: {status.branch or 'detached'}")
+    print(f"Clean: {status.clean}")
+    print(f"Datasets: {status.dataset_count}")
+    print(f"Git remote: {status.active_git_remote or 'unknown'}")
+    print(f"DVC remote: {status.active_dvc_remote or 'unknown'}")
+    return 0
+
+
+def _run_sync(args: argparse.Namespace) -> int:
+    core, projects = _build_core()
+    project = _select_project(projects, args.project)
+
+    success, message = core.fetch(
+        project=project,
+        allow_dirty=args.allow_dirty,
+        progress_cb=_progress_printer,
+        error_cb=_error_printer,
+    )
+    if not success:
+        print(f"\nFetch failed: {message}", file=sys.stderr)
+        return 1
+
+    print(f"Fetch: {message}")
+    if args.fetch_only:
+        return 0
+
+    success, message = core.publish(
+        project=project,
+        commit_message=args.message,
+        dataset_id=args.dataset_id,
+        paths_to_add=args.path or ["."],
+        progress_cb=_progress_printer,
+        error_cb=_error_printer,
+    )
+    if not success:
+        print(f"\nPublish failed: {message}", file=sys.stderr)
+        return 1
+
+    print(f"Publish: {message}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="datagest", description="DataGest headless CLI")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    status_parser = subparsers.add_parser("status", help="Show workspace state for a project")
+    status_parser.add_argument("--project", help="Project ID (optional when registry has one project)")
+    status_parser.set_defaults(handler=_run_status)
+
+    sync_parser = subparsers.add_parser("sync", help="Fetch and optionally publish workspace changes")
+    sync_parser.add_argument("--project", help="Project ID (optional when registry has one project)")
+    sync_parser.add_argument("--allow-dirty", action="store_true", help="Allow fetch when workspace is dirty")
+    sync_parser.add_argument("--fetch-only", action="store_true", help="Only run fetch, skip publish")
+    sync_parser.add_argument("--dataset-id", help="Publish only a specific dataset")
+    sync_parser.add_argument(
+        "--message",
+        default="CLI sync update",
+        help="Commit message used for publish",
+    )
+    sync_parser.add_argument(
+        "--path",
+        action="append",
+        default=None,
+        help="Path to stage during publish (repeatable)",
+    )
+    sync_parser.set_defaults(handler=_run_sync)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return int(args.handler(args))
+    except Exception as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.11"
 dependencies = [
   "PySide6>=6.6",
   "PyYAML>=6.0",
+  "keyring>=25.0",
 ]
 
 [project.optional-dependencies]

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,5 +1,6 @@
 from .api import CoreCancelled, CoreStatus, DataGestCore
 from .config import AppConfig, load_config, save_config
+from .credential_manager import CredentialManager
 from .dvc_manager import DVCError, DVCManager
 from .git_manager import GitError, GitManager
 from .lock_manager import LockInfo, LockManager
@@ -11,6 +12,7 @@ __all__ = [
     "CoreCancelled",
     "CoreStatus",
     "DataGestCore",
+    "CredentialManager",
     "AppConfig",
     "load_config",
     "save_config",

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,3 +1,4 @@
+from .api import CoreCancelled, CoreStatus, DataGestCore
 from .config import AppConfig, load_config, save_config
 from .dvc_manager import DVCError, DVCManager
 from .git_manager import GitError, GitManager
@@ -7,6 +8,9 @@ from .tool_bootstrap import ToolBootstrap
 from .workspace import WorkspaceManager, WorkspaceState
 
 __all__ = [
+    "CoreCancelled",
+    "CoreStatus",
+    "DataGestCore",
     "AppConfig",
     "load_config",
     "save_config",

--- a/src/core/api.py
+++ b/src/core/api.py
@@ -1,0 +1,605 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+import re
+from typing import Callable
+
+import yaml
+
+from core.git_manager import GitError
+from core.lock_manager import LockManager
+from core.workspace import WorkspaceManager, WorkspaceState
+from models.project import CommitInfo, DatasetConfig, ProjectConfig
+from utils.file_utils import clear_folder, copy_files, validate_image_folder
+
+ProgressCB = Callable[[str, int], None]
+ErrorCB = Callable[[str], None]
+CancelCB = Callable[[], bool]
+
+
+class CoreCancelled(RuntimeError):
+    pass
+
+
+@dataclass(slots=True)
+class CoreStatus:
+    project_id: str
+    workspace_path: Path
+    state: WorkspaceState
+    branch: str | None
+    clean: bool
+    active_git_remote: str | None
+    active_dvc_remote: str | None
+    dataset_count: int
+
+
+class DataGestCore:
+    def __init__(self, workspace: WorkspaceManager, lock_manager: LockManager | None = None) -> None:
+        self.workspace = workspace
+        self.lock_manager = lock_manager
+
+    def import_dataset(
+        self,
+        project: ProjectConfig,
+        dataset: DatasetConfig,
+        source_folder: Path,
+        description: str | None = None,
+        replace_dataset: bool = False,
+        progress_cb: ProgressCB | None = None,
+        error_cb: ErrorCB | None = None,
+        cancel_cb: CancelCB | None = None,
+    ) -> tuple[bool, str]:
+        if self.lock_manager is None:
+            raise RuntimeError("Import operation requires a lock manager.")
+
+        lock_acquired = False
+        try:
+            self._emit_progress(progress_cb, cancel_cb, "Preparing workspace", 2)
+            initialized = self.workspace.init_workspace(project)
+            if not initialized:
+                raise RuntimeError("Workspace initialization failed.")
+
+            source = Path(source_folder)
+            self._emit_progress(progress_cb, cancel_cb, "Validating image folder", 8)
+            valid, message, file_count, _ = validate_image_folder(source)
+            if not valid:
+                raise RuntimeError(message)
+
+            self._emit_progress(progress_cb, cancel_cb, "Acquiring dataset lock", 12)
+            existing = self.lock_manager.check(project.project_id, dataset.dataset_id)
+            if existing and not self.lock_manager.is_stale(existing):
+                since = existing.timestamp
+                try:
+                    ts = datetime.fromisoformat(existing.timestamp)
+                    since = ts.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+                except ValueError:
+                    pass
+                raise RuntimeError(
+                    f"Dataset locked by {existing.username} on {existing.machine} since {since}."
+                )
+
+            lock_acquired = self.lock_manager.acquire(project.project_id, dataset.dataset_id)
+            if not lock_acquired:
+                raise RuntimeError("Could not acquire dataset lock.")
+
+            self._emit_progress(progress_cb, cancel_cb, "Synchronizing workspace", 20)
+            self._run_network_op_with_retry(
+                lambda: self.workspace.git.pull(rebase=True),
+                "Git pull",
+                progress_cb=progress_cb,
+                cancel_cb=cancel_cb,
+            )
+            self._check_cancelled(cancel_cb)
+            self._run_network_op_with_retry(
+                lambda: self.workspace.dvc.pull(progress_cb=progress_cb),
+                "DVC pull",
+                progress_cb=progress_cb,
+                cancel_cb=cancel_cb,
+            )
+            self._check_cancelled(cancel_cb)
+
+            dataset_root = self.workspace.get_dataset_path(dataset.dataset_id)
+            data_dir = dataset_root / "data"
+            data_dir.mkdir(parents=True, exist_ok=True)
+
+            removed_count = 0
+            if replace_dataset:
+                self._emit_progress(progress_cb, cancel_cb, "Cleaning existing dataset files", 30)
+                removed_count = clear_folder(data_dir)
+
+            self._emit_progress(progress_cb, cancel_cb, "Copying image files", 40)
+            copy_files(source, data_dir, progress_callback=lambda msg, pct: self._emit_progress(progress_cb, cancel_cb, msg, pct))
+            self._check_cancelled(cancel_cb)
+
+            metadata = {
+                "dataset_id": dataset.dataset_id,
+                "name": dataset.name,
+                "description": dataset.description,
+                "source": dataset.source,
+                "created": datetime.now(timezone.utc).isoformat(),
+                "linked_models": [],
+                "import_note": description or f"Import into {dataset.name}",
+            }
+            with (dataset_root / "dataset.yaml").open("w", encoding="utf-8") as f:
+                yaml.safe_dump(metadata, f, sort_keys=False)
+
+            rel_data = f"datasets/{dataset.dataset_id}/data"
+            rel_dvc = f"datasets/{dataset.dataset_id}/data.dvc"
+            rel_meta = f"datasets/{dataset.dataset_id}/dataset.yaml"
+
+            self._emit_progress(progress_cb, cancel_cb, "Tracking data with DVC", 65)
+            self.workspace.dvc.add(
+                [rel_data],
+                progress_cb=lambda msg, pct: self._emit_progress(progress_cb, cancel_cb, msg, pct),
+            )
+            self._check_cancelled(cancel_cb)
+
+            self._emit_progress(progress_cb, cancel_cb, "Creating commit", 80)
+            workspace_root = dataset_root.parent.parent
+            stage_candidates = [
+                (rel_dvc, dataset_root / "data.dvc"),
+                (rel_meta, dataset_root / "dataset.yaml"),
+                (f"datasets/{dataset.dataset_id}/.gitignore", dataset_root / ".gitignore"),
+                (".gitignore", workspace_root / ".gitignore"),
+            ]
+            stage_paths = [rel_path for rel_path, abs_path in stage_candidates if abs_path.exists()]
+            if not stage_paths:
+                raise RuntimeError("No files available to stage for commit.")
+            self.workspace.git.add(stage_paths)
+
+            commit_message = (
+                f"Replace: {file_count} images into {dataset.name}"
+                if replace_dataset
+                else f"Import: {file_count} images into {dataset.name}"
+            )
+
+            has_changes = True
+            try:
+                self.workspace.git.commit(commit_message)
+            except GitError as exc:
+                if "nothing to commit" in str(exc).lower():
+                    has_changes = False
+                else:
+                    raise
+
+            if has_changes:
+                self._emit_progress(progress_cb, cancel_cb, "Pushing data to DVC remote", 88)
+                self._run_network_op_with_retry(
+                    lambda: self.workspace.dvc.push(
+                        progress_cb=lambda msg, pct: self._emit_progress(progress_cb, cancel_cb, msg, pct)
+                    ),
+                    "DVC push",
+                    progress_cb=progress_cb,
+                    cancel_cb=cancel_cb,
+                )
+                self._check_cancelled(cancel_cb)
+                self._emit_progress(progress_cb, cancel_cb, "Pushing commit to Git remote", 95)
+                self._run_network_op_with_retry(
+                    lambda: self.workspace.git.push(remote="origin", branch="main"),
+                    "Git push",
+                    progress_cb=progress_cb,
+                    cancel_cb=cancel_cb,
+                )
+            else:
+                self._emit_progress(progress_cb, cancel_cb, "No changes to push", 95)
+
+            self._emit_progress(progress_cb, cancel_cb, "Import complete", 100)
+            if replace_dataset:
+                return (
+                    True,
+                    f"Replaced dataset with {file_count} images (removed {removed_count} previous files).",
+                )
+            if has_changes:
+                return True, f"Imported and published {file_count} images."
+            return True, "No dataset change detected; data already up to date."
+        except CoreCancelled as exc:
+            return False, str(exc)
+        except Exception as exc:
+            self._emit_error(error_cb, str(exc))
+            return False, str(exc)
+        finally:
+            if lock_acquired:
+                self.lock_manager.release(project.project_id, dataset.dataset_id)
+
+    def fetch(
+        self,
+        project: ProjectConfig,
+        allow_dirty: bool = False,
+        progress_cb: ProgressCB | None = None,
+        error_cb: ErrorCB | None = None,
+        cancel_cb: CancelCB | None = None,
+    ) -> tuple[bool, str]:
+        try:
+            self._emit_progress(progress_cb, cancel_cb, "Preparing workspace", 5)
+            self.workspace.init_workspace(project)
+            self._check_cancelled(cancel_cb)
+
+            status = self.workspace.git.status()
+            if not status.clean and not allow_dirty:
+                raise RuntimeError(
+                    "Workspace has local changes. Commit or discard them before fetching latest."
+                )
+
+            self._emit_progress(progress_cb, cancel_cb, "Pulling latest Git commits", 30)
+            self._run_network_op_with_retry(
+                lambda: self.workspace.git.pull(rebase=True),
+                "Git pull",
+                progress_cb=progress_cb,
+                cancel_cb=cancel_cb,
+            )
+            self._check_cancelled(cancel_cb)
+
+            self._emit_progress(progress_cb, cancel_cb, "Pulling latest DVC objects", 55)
+            self._run_network_op_with_retry(
+                lambda: self.workspace.dvc.pull(
+                    progress_cb=lambda msg, pct: self._emit_progress(progress_cb, cancel_cb, msg, pct)
+                ),
+                "DVC pull",
+                progress_cb=progress_cb,
+                cancel_cb=cancel_cb,
+            )
+            self._check_cancelled(cancel_cb)
+
+            self._emit_progress(progress_cb, cancel_cb, "Checking out data", 80)
+            self.workspace.dvc.checkout(
+                progress_cb=lambda msg, pct: self._emit_progress(progress_cb, cancel_cb, msg, pct)
+            )
+
+            branch = self.workspace.git.current_branch() or "detached"
+            self._emit_progress(progress_cb, cancel_cb, "Fetch complete", 100)
+            return True, f"Workspace synced on {branch}."
+        except CoreCancelled as exc:
+            return False, str(exc)
+        except Exception as exc:
+            self._emit_error(error_cb, str(exc))
+            return False, str(exc)
+
+    def publish(
+        self,
+        project: ProjectConfig,
+        commit_message: str,
+        dataset_id: str | None = None,
+        paths_to_add: list[str] | None = None,
+        progress_cb: ProgressCB | None = None,
+        error_cb: ErrorCB | None = None,
+        cancel_cb: CancelCB | None = None,
+    ) -> tuple[bool, str]:
+        try:
+            self._emit_progress(progress_cb, cancel_cb, "Preparing workspace", 5)
+            self.workspace.init_workspace(project)
+            self._check_cancelled(cancel_cb)
+
+            current_branch = self.workspace.git.current_branch()
+            if current_branch is None:
+                raise RuntimeError(
+                    "Workspace is on a restored commit (detached HEAD). Return to latest before publishing."
+                )
+
+            if current_branch != "main":
+                self._emit_progress(progress_cb, cancel_cb, "Switching to main", 10)
+                self.workspace.git.checkout("main")
+                self._check_cancelled(cancel_cb)
+
+            add_paths = list(paths_to_add or ["."])
+            if dataset_id:
+                rel_data = f"datasets/{dataset_id}/data"
+                rel_dataset = f"datasets/{dataset_id}"
+                self._emit_progress(progress_cb, cancel_cb, "Tracking dataset changes with DVC", 18)
+                self.workspace.dvc.add(
+                    [rel_data],
+                    progress_cb=lambda msg, pct: self._emit_progress(progress_cb, cancel_cb, msg, pct),
+                )
+                add_paths = ["-A", rel_dataset]
+
+            self._emit_progress(progress_cb, cancel_cb, "Staging files", 30)
+            self.workspace.git.add(add_paths)
+            self._check_cancelled(cancel_cb)
+
+            self._emit_progress(progress_cb, cancel_cb, "Creating commit", 45)
+            has_changes = True
+            try:
+                self.workspace.git.commit(commit_message)
+            except GitError as exc:
+                if "nothing to commit" in str(exc).lower():
+                    has_changes = False
+                else:
+                    raise
+
+            if not has_changes:
+                self._emit_progress(progress_cb, cancel_cb, "No changes to publish", 100)
+                return True, "No local change detected."
+
+            self._emit_progress(progress_cb, cancel_cb, "Rebasing on latest main", 62)
+            self._run_network_op_with_retry(
+                lambda: self.workspace.git.pull(rebase=True),
+                "Git pull",
+                progress_cb=progress_cb,
+                cancel_cb=cancel_cb,
+            )
+            self._check_cancelled(cancel_cb)
+
+            self._emit_progress(progress_cb, cancel_cb, "Pushing DVC data", 78)
+            self._run_network_op_with_retry(
+                lambda: self.workspace.dvc.push(
+                    progress_cb=lambda msg, pct: self._emit_progress(progress_cb, cancel_cb, msg, pct)
+                ),
+                "DVC push",
+                progress_cb=progress_cb,
+                cancel_cb=cancel_cb,
+            )
+            self._check_cancelled(cancel_cb)
+
+            self._emit_progress(progress_cb, cancel_cb, "Pushing Git commit", 90)
+            try:
+                self._run_network_op_with_retry(
+                    lambda: self.workspace.git.push(remote="origin", branch="main"),
+                    "Git push",
+                    progress_cb=progress_cb,
+                    cancel_cb=cancel_cb,
+                )
+            except GitError as exc:
+                if not self._is_non_fast_forward_error(str(exc)):
+                    raise
+                self._emit_progress(progress_cb, cancel_cb, "Remote moved, rebasing and retrying push", 94)
+                self._run_network_op_with_retry(
+                    lambda: self.workspace.git.pull(rebase=True),
+                    "Git pull",
+                    progress_cb=progress_cb,
+                    cancel_cb=cancel_cb,
+                )
+                self._run_network_op_with_retry(
+                    lambda: self.workspace.git.push(remote="origin", branch="main"),
+                    "Git push",
+                    progress_cb=progress_cb,
+                    cancel_cb=cancel_cb,
+                )
+
+            self._emit_progress(progress_cb, cancel_cb, "Publish complete", 100)
+            return True, "Changes published."
+        except CoreCancelled as exc:
+            return False, str(exc)
+        except Exception as exc:
+            self._emit_error(error_cb, str(exc))
+            return False, str(exc)
+
+    def load_history(
+        self,
+        project: ProjectConfig,
+        dataset_id: str,
+        max_count: int = 50,
+        progress_cb: ProgressCB | None = None,
+        error_cb: ErrorCB | None = None,
+        cancel_cb: CancelCB | None = None,
+    ) -> tuple[bool, str, list[CommitInfo]]:
+        commits: list[CommitInfo] = []
+        try:
+            self._emit_progress(progress_cb, cancel_cb, "Preparing workspace", 10)
+            self.workspace.init_workspace(project)
+            self._check_cancelled(cancel_cb)
+
+            self._emit_progress(progress_cb, cancel_cb, "Loading history", 60)
+            commits = self.workspace.git.log(path_filter=f"datasets/{dataset_id}", max_count=max_count)
+            self._check_cancelled(cancel_cb)
+
+            self._emit_progress(progress_cb, cancel_cb, "Analyzing image changes", 80)
+            self._populate_image_deltas(dataset_id, commits)
+            self._emit_progress(progress_cb, cancel_cb, "History loaded", 100)
+            return True, f"Loaded {len(commits)} commits.", commits
+        except CoreCancelled as exc:
+            return False, str(exc), commits
+        except Exception as exc:
+            self._emit_error(error_cb, str(exc))
+            return False, str(exc), commits
+
+    def restore(
+        self,
+        project: ProjectConfig,
+        commit_ref: str,
+        progress_cb: ProgressCB | None = None,
+        error_cb: ErrorCB | None = None,
+        cancel_cb: CancelCB | None = None,
+    ) -> tuple[bool, str]:
+        try:
+            self._emit_progress(progress_cb, cancel_cb, "Preparing workspace", 15)
+            self.workspace.init_workspace(project)
+            self._check_cancelled(cancel_cb)
+
+            self._emit_progress(progress_cb, cancel_cb, "Checking out commit", 45)
+            self.workspace.git.checkout(commit_ref)
+            self._check_cancelled(cancel_cb)
+
+            self._emit_progress(progress_cb, cancel_cb, "Restoring files with DVC", 75)
+            self.workspace.dvc.checkout(
+                progress_cb=lambda msg, pct: self._emit_progress(progress_cb, cancel_cb, msg, pct)
+            )
+            self._check_cancelled(cancel_cb)
+
+            self._emit_progress(progress_cb, cancel_cb, "Restore complete", 100)
+            return True, f"Restored {commit_ref}"
+        except CoreCancelled as exc:
+            return False, str(exc)
+        except Exception as exc:
+            self._emit_error(error_cb, str(exc))
+            return False, str(exc)
+
+    def return_to_latest(
+        self,
+        project: ProjectConfig,
+        progress_cb: ProgressCB | None = None,
+        error_cb: ErrorCB | None = None,
+        cancel_cb: CancelCB | None = None,
+    ) -> tuple[bool, str]:
+        try:
+            self._emit_progress(progress_cb, cancel_cb, "Preparing workspace", 10)
+            self.workspace.init_workspace(project)
+            self._check_cancelled(cancel_cb)
+
+            self._emit_progress(progress_cb, cancel_cb, "Checking out main", 30)
+            self.workspace.git.checkout("main")
+            self._check_cancelled(cancel_cb)
+
+            self._emit_progress(progress_cb, cancel_cb, "Pulling latest Git", 50)
+            self._run_network_op_with_retry(
+                lambda: self.workspace.git.pull(rebase=True),
+                "Git pull",
+                progress_cb=progress_cb,
+                cancel_cb=cancel_cb,
+            )
+            self._check_cancelled(cancel_cb)
+
+            self._emit_progress(progress_cb, cancel_cb, "Pulling latest DVC", 70)
+            self._run_network_op_with_retry(
+                lambda: self.workspace.dvc.pull(
+                    progress_cb=lambda msg, pct: self._emit_progress(progress_cb, cancel_cb, msg, pct)
+                ),
+                "DVC pull",
+                progress_cb=progress_cb,
+                cancel_cb=cancel_cb,
+            )
+            self._check_cancelled(cancel_cb)
+
+            self._emit_progress(progress_cb, cancel_cb, "Applying data checkout", 90)
+            self.workspace.dvc.checkout(
+                progress_cb=lambda msg, pct: self._emit_progress(progress_cb, cancel_cb, msg, pct)
+            )
+            self._check_cancelled(cancel_cb)
+
+            self._emit_progress(progress_cb, cancel_cb, "Workspace on latest", 100)
+            return True, "Returned to latest main"
+        except CoreCancelled as exc:
+            return False, str(exc)
+        except Exception as exc:
+            self._emit_error(error_cb, str(exc))
+            return False, str(exc)
+
+    def get_status(self, project: ProjectConfig) -> CoreStatus:
+        self.workspace.init_workspace(project)
+        git_status = self.workspace.git.status()
+        state = self.workspace.get_state()
+        datasets = self.workspace.list_datasets()
+        return CoreStatus(
+            project_id=project.project_id,
+            workspace_path=self.workspace.workspace_path,
+            state=state,
+            branch=git_status.branch,
+            clean=git_status.clean,
+            active_git_remote=self.workspace.active_git_remote,
+            active_dvc_remote=self.workspace.active_dvc_remote,
+            dataset_count=len(datasets),
+        )
+
+    def _dvc_nfiles(self, text: str | None) -> int | None:
+        if not text:
+            return None
+        match = re.search(r"^\s*nfiles:\s*(\d+)\s*$", text, re.MULTILINE)
+        if not match:
+            return None
+        return int(match.group(1))
+
+    def _git_show_file(self, commit_hash: str, relative_path: str) -> str | None:
+        try:
+            return self.workspace.git.run(["show", f"{commit_hash}:{relative_path}"])
+        except Exception:
+            return None
+
+    def _first_parent(self, commit_hash: str) -> str | None:
+        try:
+            output = self.workspace.git.run(["rev-list", "--parents", "-n", "1", commit_hash]).strip()
+        except Exception:
+            return None
+        parts = output.split()
+        return parts[1] if len(parts) > 1 else None
+
+    def _populate_image_deltas(self, dataset_id: str, commits: list[CommitInfo]) -> None:
+        data_dvc = f"datasets/{dataset_id}/data.dvc"
+        for commit in commits:
+            current_nfiles = self._dvc_nfiles(self._git_show_file(commit.hash, data_dvc))
+            parent_hash = self._first_parent(commit.hash)
+            previous_nfiles = self._dvc_nfiles(self._git_show_file(parent_hash, data_dvc)) if parent_hash else 0
+
+            if current_nfiles is None and previous_nfiles is None:
+                commit.images_added = 0
+                commit.images_removed = 0
+                continue
+
+            current = current_nfiles or 0
+            previous = previous_nfiles or 0
+            delta = current - previous
+            commit.images_added = max(delta, 0)
+            commit.images_removed = max(-delta, 0)
+
+    def _check_cancelled(self, cancel_cb: CancelCB | None) -> None:
+        if cancel_cb and cancel_cb():
+            raise CoreCancelled("Cancelled by user.")
+
+    def _emit_progress(
+        self,
+        progress_cb: ProgressCB | None,
+        cancel_cb: CancelCB | None,
+        message: str,
+        percent: int,
+    ) -> None:
+        self._check_cancelled(cancel_cb)
+        if progress_cb:
+            progress_cb(message, max(0, min(100, percent)))
+
+    def _emit_error(self, error_cb: ErrorCB | None, message: str) -> None:
+        if error_cb:
+            error_cb(message)
+
+    def _is_non_fast_forward_error(self, message: str) -> bool:
+        lowered = message.lower()
+        return "non-fast-forward" in lowered or "failed to push some refs" in lowered
+
+    def _is_retryable_network_error(self, message: str) -> bool:
+        lowered = message.lower()
+        markers = (
+            "network",
+            "timed out",
+            "timeout",
+            "temporarily unavailable",
+            "connection reset",
+            "connection aborted",
+            "could not resolve host",
+            "unable to access",
+            "transport endpoint",
+            "broken pipe",
+            "resource busy",
+            "name or service not known",
+        )
+        return any(marker in lowered for marker in markers)
+
+    def _run_network_op_with_retry(
+        self,
+        operation: Callable[[], None],
+        label: str,
+        progress_cb: ProgressCB | None = None,
+        cancel_cb: CancelCB | None = None,
+        retries: int = 3,
+    ) -> None:
+        attempts = max(retries, 1)
+        for attempt in range(1, attempts + 1):
+            self._check_cancelled(cancel_cb)
+            try:
+                operation()
+                return
+            except CoreCancelled:
+                raise
+            except Exception as exc:
+                is_last = attempt >= attempts
+                retryable = self._is_retryable_network_error(str(exc))
+                if is_last or not retryable:
+                    raise
+
+                delay = min(8.0, 0.75 * (2 ** (attempt - 1)))
+                first_line = str(exc).splitlines()[0] if str(exc).strip() else "network error"
+                self._emit_progress(
+                    progress_cb,
+                    cancel_cb,
+                    f"{label} failed ({first_line}). Retrying in {delay:.1f}s (attempt {attempt + 1}/{attempts})",
+                    0,
+                )
+                time.sleep(delay)

--- a/src/core/credential_manager.py
+++ b/src/core/credential_manager.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+try:
+    import keyring as _keyring
+except ModuleNotFoundError:
+    _keyring = None
+
+
+def _set_password(service: str, username: str, token: str) -> None:
+    if _keyring is None:
+        raise RuntimeError("keyring package is not installed. Install dependencies to use credential storage.")
+    _keyring.set_password(service, username, token)
+
+
+def _get_password(service: str, username: str) -> str | None:
+    if _keyring is None:
+        raise RuntimeError("keyring package is not installed. Install dependencies to use credential storage.")
+    return _keyring.get_password(service, username)
+
+
+class CredentialManager:
+    def set_token(self, service: str, username: str, token: str) -> None:
+        _set_password(service, username, token)
+
+    def get_token(self, service: str, username: str) -> str | None:
+        return _get_password(service, username)

--- a/src/core/dvc_manager.py
+++ b/src/core/dvc_manager.py
@@ -12,6 +12,12 @@ from utils.platform import get_app_gitconfig_path
 
 CREATE_NO_WINDOW = 0x08000000 if os.name == "nt" else 0
 
+
+def _popen_kwargs() -> dict:
+    if os.name == "nt":
+        return {"creationflags": CREATE_NO_WINDOW}
+    return {}
+
 ProgressCB = Callable[[str, int], None]
 
 
@@ -65,10 +71,10 @@ class DVCManager:
             cwd=cwd or self.workspace,
             capture_output=True,
             text=True,
-            creationflags=CREATE_NO_WINDOW,
             env=self._base_env(),
             timeout=self.timeout_seconds if self.timeout_seconds > 0 else None,
             check=False,
+            **_popen_kwargs(),
         )
 
     def _run_checked(self, args: Sequence[str], cwd: Path | None = None) -> str:
@@ -103,8 +109,8 @@ class DVCManager:
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 text=True,
-                creationflags=CREATE_NO_WINDOW,
                 env=self._base_env(),
+                **_popen_kwargs(),
             )
             timed_out = {"value": False}
 

--- a/src/core/git_manager.py
+++ b/src/core/git_manager.py
@@ -14,6 +14,12 @@ from utils.platform import get_app_gitconfig_path
 CREATE_NO_WINDOW = 0x08000000 if os.name == "nt" else 0
 
 
+def _popen_kwargs() -> dict:
+    if os.name == "nt":
+        return {"creationflags": CREATE_NO_WINDOW}
+    return {}
+
+
 class GitError(RuntimeError):
     pass
 
@@ -78,10 +84,10 @@ class GitManager:
             cwd=run_cwd,
             capture_output=True,
             text=True,
-            creationflags=CREATE_NO_WINDOW,
             env=env,
             timeout=self.timeout_seconds if self.timeout_seconds > 0 else None,
             check=False,
+            **_popen_kwargs(),
         )
 
     def run(self, args: Sequence[str], cwd: Path | None = None) -> str:

--- a/src/utils/platform.py
+++ b/src/utils/platform.py
@@ -1,27 +1,38 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
+import getpass
 import os
-import platform
 from pathlib import Path
 import re
+import socket
 
 
 def get_windows_username() -> str:
     try:
-        return os.getlogin()
-    except OSError:
+        username = getpass.getuser()
+        return username or "unknown"
+    except Exception:
         return os.environ.get("USERNAME") or os.environ.get("USER") or "unknown"
 
 
 def get_machine_name() -> str:
-    return platform.node() or "unknown-machine"
+    try:
+        name = socket.gethostname()
+        return name or "unknown-machine"
+    except Exception:
+        return "unknown-machine"
 
 
 def get_local_appdata() -> Path:
-    root = os.environ.get("LOCALAPPDATA")
-    if root:
-        return Path(root) / "DataGest"
-    return Path.home() / ".datagest"
+    if os.name == "nt":
+        root = os.environ.get("LOCALAPPDATA")
+        if root:
+            return Path(root) / "DataGest"
+        return Path.home() / "AppData" / "Local" / "DataGest"
+
+    xdg_root = os.environ.get("XDG_CONFIG_HOME")
+    base = Path(xdg_root) if xdg_root else Path.home() / ".config"
+    return base / "datagest"
 
 
 def get_app_gitconfig_path() -> Path | None:

--- a/src/version.py
+++ b/src/version.py
@@ -1,3 +1,3 @@
 """Application version (single source of truth)."""
 
-APP_VERSION = "0.5.1"
+APP_VERSION = "0.6.0"

--- a/src/workflows/base.py
+++ b/src/workflows/base.py
@@ -1,41 +1,41 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import time
 from typing import Callable
 
-try:
-    from PySide6.QtCore import QObject, Signal
-except ModuleNotFoundError:
-    class _BoundSignal:
-        def __init__(self) -> None:
-            self._callbacks: list[Callable] = []
 
-        def connect(self, callback: Callable) -> None:
-            self._callbacks.append(callback)
+class _BoundSignal:
+    def __init__(self) -> None:
+        self._callbacks: list[Callable] = []
 
-        def emit(self, *args, **kwargs) -> None:
-            for callback in list(self._callbacks):
-                callback(*args, **kwargs)
+    def connect(self, callback: Callable) -> None:
+        self._callbacks.append(callback)
 
-    class Signal:  # type: ignore[misc]
-        def __init__(self, *args, **kwargs) -> None:
-            self.name: str | None = None
+    def emit(self, *args, **kwargs) -> None:
+        for callback in list(self._callbacks):
+            callback(*args, **kwargs)
 
-        def __set_name__(self, owner, name) -> None:
-            self.name = name
 
-        def __get__(self, instance, owner):
-            if instance is None:
-                return self
-            store = instance.__dict__.setdefault("_signals", {})
-            assert self.name is not None
-            if self.name not in store:
-                store[self.name] = _BoundSignal()
-            return store[self.name]
+class Signal:  # type: ignore[misc]
+    def __init__(self, *args, **kwargs) -> None:
+        self.name: str | None = None
 
-    class QObject:  # type: ignore[misc]
-        def __init__(self) -> None:
-            pass
+    def __set_name__(self, owner, name) -> None:
+        self.name = name
+
+    def __get__(self, instance, owner):
+        if instance is None:
+            return self
+        store = instance.__dict__.setdefault("_signals", {})
+        assert self.name is not None
+        if self.name not in store:
+            store[self.name] = _BoundSignal()
+        return store[self.name]
+
+
+class QObject:  # type: ignore[misc]
+    def __init__(self) -> None:
+        pass
 
 
 class BaseWorkflow(QObject):

--- a/tests/test_credential_manager.py
+++ b/tests/test_credential_manager.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import core.credential_manager as credential_module
+from core.credential_manager import CredentialManager
+
+
+def test_set_and_get_token_with_keyring(monkeypatch) -> None:
+    store: dict[tuple[str, str], str] = {}
+
+    def fake_set_password(service: str, username: str, token: str) -> None:
+        store[(service, username)] = token
+
+    def fake_get_password(service: str, username: str) -> str | None:
+        return store.get((service, username))
+
+    monkeypatch.setattr(credential_module, "_set_password", fake_set_password)
+    monkeypatch.setattr(credential_module, "_get_password", fake_get_password)
+
+    manager = CredentialManager()
+    manager.set_token("datagest", "user1", "secret-token")
+
+    assert manager.get_token("datagest", "user1") == "secret-token"

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 from utils.platform import get_app_gitconfig_path, validate_unc_path
@@ -18,7 +19,10 @@ def test_validate_unc_accepts_unc_syntax_without_existence_check() -> None:
 
 
 def test_get_app_gitconfig_path_uses_local_appdata(monkeypatch, tmp_path: Path) -> None:
-    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
+    if os.name == "nt":
+        monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
+    else:
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
     path = get_app_gitconfig_path()
     assert path is not None
     assert path.name == "gitconfig"

--- a/tests/test_tool_bootstrap.py
+++ b/tests/test_tool_bootstrap.py
@@ -6,6 +6,23 @@ from core.config import AppConfig
 from core.tool_bootstrap import ToolBootstrap
 
 
+def test_ensure_git_prefers_system_path(tmp_path: Path, monkeypatch) -> None:
+    bootstrap = ToolBootstrap(AppConfig(), tools_dir=tmp_path)
+    monkeypatch.setattr("core.tool_bootstrap.shutil.which", lambda name: "/usr/bin/git" if name == "git" else None)
+
+    git_path = bootstrap.ensure_git()
+    assert git_path == Path("/usr/bin/git")
+
+
+def test_find_dvc_cli_checks_system_path_first(tmp_path: Path, monkeypatch) -> None:
+    bootstrap = ToolBootstrap(AppConfig(), tools_dir=tmp_path)
+    monkeypatch.setattr("core.tool_bootstrap.shutil.which", lambda name: "/usr/bin/dvc" if name == "dvc" else None)
+    monkeypatch.setattr(bootstrap, "_is_valid_dvc_exe", lambda path: True)
+
+    dvc_path = bootstrap._find_dvc_cli()
+    assert dvc_path == Path("/usr/bin/dvc")
+
+
 def test_resolve_dvc_source_keeps_preferred_when_available(tmp_path: Path, monkeypatch) -> None:
     bootstrap = ToolBootstrap(AppConfig(), tools_dir=tmp_path)
     monkeypatch.setattr(bootstrap, "_url_exists", lambda url: url == "https://preferred")


### PR DESCRIPTION
## Summary
Closes #1, #2, #3, #4.

This PR delivers the full v0.6.0 foundation scope:
- Core business logic decoupled from PySide6 into a pure Python API
- Cross-platform tool/bootstrap and platform path handling
- Headless CLI entry point with `status` and `sync`
- Keyring-backed credential storage utility + tests

## Issue #1: Core API Refactor
- Added pure callback-based core facade in `src/core/api.py`:
- `import_dataset`
- `publish`
- `fetch`
- `restore`
- `return_to_latest`
- `load_history`
- `get_status`
- Removed PySide6 dependency from `src/workflows/base.py`.
- Refactored `src/ui/app.py` to own Qt threading via `CoreTaskRunner` and call core API methods through callbacks (`progress_cb`, `error_cb`, `cancel_cb`).

## Issue #2: OS-Agnostic Tooling/Paths
- Updated `src/utils/platform.py`:
- username via `getpass.getuser()`
- machine name via `socket.gethostname()`
- Unix config path support via `~/.config/datagest` (or `XDG_CONFIG_HOME`)
- Updated subprocess handling in:
- `src/core/git_manager.py`
- `src/core/dvc_manager.py`
- `src/core/tool_bootstrap.py`
- `creationflags` now apply only on Windows.
- Updated `ToolBootstrap` to prefer system `git`/`dvc` on PATH and avoid Windows-only bootstrap behavior on Unix.

## Issue #3: Headless CLI
- Added root `cli.py` using `argparse`.
- Implemented:
- `datagest status` (workspace/project state output)
- `datagest sync` (fetch + optional publish with console progress bar)
- Confirmed CLI path does not import/trigger PySide6 modules.

## Issue #4: Keyring Credential Manager
- Added dependency `keyring>=25.0` in `pyproject.toml`.
- Added `src/core/credential_manager.py` with:
- `set_token(service, username, token)`
- `get_token(service, username)`
- Added `tests/test_credential_manager.py` validating token read/write behavior (mocked keyring hooks).

## Validation
- `python -m pytest -q` -> `71 passed`
- `python -m ruff check .` -> passed
- `python cli.py --help` -> passed

## Commits
- `2e17453` refactor(core): extract pure callback-based core API and move Qt threading to UI
- `da93681` feat(platform): make tool/bootstrap and process handling OS-agnostic
- `f0f2757` feat(cli): add headless datagest status and sync commands
- `9e0bf4f` feat(security): add keyring-backed credential manager and tests